### PR TITLE
[gencon] Make segment discovery  consistent

### DIFF
--- a/src/gencon/gencon.h
+++ b/src/gencon/gencon.h
@@ -50,6 +50,7 @@ int read_co2_mesh(Mesh *mesh, char *fname, struct comm *c);
 int findMinNeighborDistance(Mesh mesh);
 int findSegments(Mesh mesh, struct comm *c, GenmapScalar tol, int verbose, buffer *bfr);
 int faceCheck(Mesh mesh, struct comm *c);
+int elementCheck(Mesh mesh, struct comm *c);
 int setGlobalID(Mesh mesh, struct comm *c);
 int sendBack(Mesh mesh, struct comm *c, buffer *bfr);
 int matchPeriodicFaces(Mesh mesh, struct comm *c, buffer *bfr);

--- a/src/gencon/segments.c
+++ b/src/gencon/segments.c
@@ -4,6 +4,32 @@
 #include <gencon-impl.h>
 #include <sort.h>
 
+static void initSegments(Mesh mesh, struct comm *c) {
+  uint nPoints = mesh->elements.n;
+  Point points = mesh->elements.ptr;
+
+  // Initialize globalId and ifSegment
+  slong out[2][1], buf[2][1], in[1];
+  in[0] = nPoints;
+  comm_scan(out, c, gs_long, gs_add, in, 1, buf);
+  slong start = out[0][0];
+  uint i;
+  for (i = 0; i < nPoints; i++) {
+    points[i].ifSegment = 0;
+    points[i].globalId = start + i;
+  }
+
+  // First rank with nPoints > 0 set ifSegment = 1
+  sint rank = c->id;
+  if (nPoints == 0)
+    rank = c->np;
+
+  comm_allreduce(c, gs_int, gs_min, &rank, 1, buf);
+
+  if (c->id == rank)
+    points[0].ifSegment = 1;
+}
+
 static int sortSegments(Mesh mesh, struct comm *c, int dim, buffer *bfr) {
   sint nPoints = mesh->elements.n;
   Point points = mesh->elements.ptr;
@@ -28,9 +54,16 @@ static int sortSegments(Mesh mesh, struct comm *c, int dim, buffer *bfr) {
         break;
     }
 
-    points[s].ifSegment = 1;
-    for (s = s + 1; s < e; s++)
-      points[s].ifSegment = 0;
+    sint i, sum = 0;
+    for (i = s + 1; i < e; i++) {
+        sum += points[i].ifSegment;
+        points[i].ifSegment = 0;
+    }
+
+    if (sum > 0)
+      points[s].ifSegment = 1;
+
+    s = e;
   }
 
   return 0;
@@ -41,9 +74,6 @@ static int findLocalSegments(Mesh mesh, int i, GenmapScalar tolSquared) {
   sint npts = mesh->elements.n;
   int nDim = mesh->nDim;
 
-  //if (npts > 0)
-  //  printf("%d %d %0.12lf %0.12lf %0.12lf %llu\n", 0, pts[0].ifSegment, pts[0].x[0], pts[0].x[1], pts[0].x[2], pts[0].globalId);
-
   sint j;
   for (j = 1; j < npts; j++) {
     GenmapScalar d = sqrDiff(pts[j].x[i], pts[j - 1].x[i]);
@@ -52,12 +82,10 @@ static int findLocalSegments(Mesh mesh, int i, GenmapScalar tolSquared) {
 
     if (d > dx)
       pts[j].ifSegment = 1;
-
-    //printf("%d %d %0.12lf %0.12lf %0.12lf %llu\n", j, pts[j].ifSegment, pts[j].x[0], pts[j].x[1], pts[j].x[2], pts[j].globalId);
   }
 }
 
-static int mergeSegments(Mesh mesh, struct comm *c, int i, GenmapScalar tolSquared, buffer *bfr) {
+static int mergeSegments(Mesh mesh, struct comm *c, int i, GenmapScalar tolSquared, int transfer, buffer *bfr) {
   uint nPoints = mesh->elements.n;
   Point points = mesh->elements.ptr;
 
@@ -90,107 +118,127 @@ static int mergeSegments(Mesh mesh, struct comm *c, int i, GenmapScalar tolSquar
 
   array_free(&arr);
 
-  // If rank > 0, send i = 0,... n-1 where points[i].ifSegment == 0 to rank - 1
-  n = 0;
-  for (; n < nPoints && points[n].ifSegment == 0; n++)
-    points[n].proc = rank - 1;
-  for (; n < nPoints; n++)
-    points[n].proc = rank;
+  if (transfer > 0) {
+    // If rank > 0, send i = 0,... n-1 where points[i].ifSegment == 0 to rank - 1
+    n = 0;
+    for (; n < nPoints && points[n].ifSegment == 0; n++)
+      points[n].proc = rank - 1;
+    for (; n < nPoints; n++)
+      points[n].proc = rank;
 
-  sarray_transfer(struct Point_private, &mesh->elements, proc, 0, &cr);
-  crystal_free(&cr);
+    sarray_transfer(struct Point_private, &mesh->elements, proc, 0, &cr);
+    crystal_free(&cr);
 
-  sarray_sort(struct Point_private, mesh->elements.ptr, mesh->elements.n, globalId, 1, bfr);
+    sarray_sort(struct Point_private, mesh->elements.ptr, mesh->elements.n, globalId, 1, bfr);
+  }
 
   return 0;
 }
 
-int findSegments(Mesh mesh, struct comm *c, GenmapScalar tol, int verbose, buffer *bfr) {
-  int nDim = mesh->nDim;
-  int nVertex = mesh->nVertex;
-  GenmapScalar tolSquared = tol*tol;
+static slong countSegments(Mesh mesh, struct comm *c) {
+  uint nPoints = mesh->elements.n;
+  Point points = mesh->elements.ptr;
 
+  sint count = 0, i;
+  for (i = 0; i < nPoints; i++)
+    if (points[i].ifSegment > 0)
+      count++;
+
+  slong in, buf[2][1];
+  in = count;
+  comm_allreduce(c, gs_long, gs_add, &in, 1, buf);
+  return in;
+}
+
+struct schedule {
+  int dim;
+  slong segments;
+};
+
+int findSegments(Mesh mesh, struct comm *c, GenmapScalar tol, int verbose, buffer *bfr) {
+  // TODO: load balance
   parallel_sort(struct Point_private, &mesh->elements, x[0], genmap_gs_scalar, bin_sort, 0, c);
 
   uint nPoints = mesh->elements.n;
   Point points = mesh->elements.ptr;
+  int nDim = mesh->nDim;
 
   if (nDim == 3)
     sarray_sort_3(struct Point_private, points, nPoints, x[0], 3, x[1], 3, x[2], 3, bfr);
   else
     sarray_sort_2(struct Point_private, points, nPoints, x[0], 3, x[1], 3, bfr);
 
-  //TODO: load balance
-
-  // Initialize globalId and ifSegment
-  slong out[2][1], buf[2][1], in[1];
-  in[0] = nPoints;
-  comm_scan(out, c, gs_long, gs_add, in, 1, buf);
-  slong start = out[0][0];
-  uint i;
-  for (i = 0; i < nPoints; i++) {
-    points[i].ifSegment = 0;
-    points[i].globalId = start + i;
-  }
-
-  //FIXME: first rank with nPoints>0 should do this
-  if (c->id == 0 && nPoints > 0)
-    points[0].ifSegment = 1;
-
   comm_ext orig;
 #ifdef MPI
   MPI_Comm_dup(c->c, &orig);
 #endif
+
   struct comm nonZeroRanks;
-  int rank = c->id;
 
-  int dim, bin, t, merged = 0;
-  for (t = 0; t < nDim; t++) {
-    for (dim = 0; dim < nDim; dim++) {
+  int bin = (nPoints > 0);
+#ifdef MPI
+  MPI_Comm new;
+  MPI_Comm_split(orig, bin, c->id, &new);
+  comm_init(&nonZeroRanks, new);
+  MPI_Comm_free(&new);
+#else
+  comm_init(&nonZeroRanks, 1);
+#endif
+
+  struct schedule sched[3];
+  GenmapScalar tolSquared = tol*tol;
+
+  int t;
+  for (t = 0; t < nDim; t++){
+    sched[t].dim = t;
+    initSegments(mesh, &nonZeroRanks);
+    findLocalSegments(mesh, t, tolSquared);
+    mergeSegments(mesh, &nonZeroRanks, t, tolSquared, 0, bfr);
+    sched[t].segments = countSegments(mesh, &nonZeroRanks);
+  }
+
+  sarray_sort(struct schedule, sched, 3, segments, 1, bfr);
+
+  initSegments(mesh, c);
+
+  int d, merge = 1, err = 0;
+
+  for (t = 0; t < nDim && err == 0; t++) {
+    for (d = nDim - 1; d >= 0; d--) {
+      int dim = sched[d].dim;
+      if (bin > 0) {
+        sortSegments(mesh, &nonZeroRanks, dim, bfr);
+        findLocalSegments(mesh, dim, tolSquared);
+
+        slong segments = countSegments(mesh, &nonZeroRanks);
+
+        int rank = nonZeroRanks.id;
+        if (rank == 0 && verbose > 0)
+          printf("\tlocglob: %d %d %lld\n", t + 1, dim + 1, segments);
+
+        mergeSegments(mesh, &nonZeroRanks, dim, tolSquared, merge, bfr);
+        merge = 0;
+      }
+
+      comm_free(&nonZeroRanks);
+
       nPoints = mesh->elements.n;
-
       bin = (nPoints > 0);
 #ifdef MPI
       MPI_Comm new;
-      MPI_Comm_split(orig, bin, rank, &new);
+      MPI_Comm_split(orig, bin, nonZeroRanks.id, &new);
       comm_init(&nonZeroRanks, new);
       MPI_Comm_free(&new);
 #else
       comm_init(&nonZeroRanks, 1);
 #endif
-
-      rank = nonZeroRanks.id;
-
-      if (bin > 0 && verbose > 0) {
-        nPoints = mesh->elements.n;
-        points = mesh->elements.ptr;
-        sint count = 0;
-        for (i = 0; i < nPoints; i++)
-          if (points[i].ifSegment > 0)
-            count++;
-
-        in[0] = count;
-        comm_allreduce(&nonZeroRanks, gs_long, gs_add, in, 1, buf);
-        if (rank == 0)
-          printf("\tlocglob: %d %d %lld\n", t + 1, dim + 1, in[0]);
-      }
-
-      if (bin > 0) {
-        sortSegments(mesh, &nonZeroRanks, dim, bfr);
-        findLocalSegments(mesh, dim, tolSquared);
-        if (merged == 0) {
-          mergeSegments(mesh, &nonZeroRanks, dim, tolSquared, bfr);
-          merged = 1;
-        }
-      }
-
-      comm_free(&nonZeroRanks);
     }
   }
 
+  comm_free(&nonZeroRanks);
 #ifdef MPI
   MPI_Comm_free(&orig);
 #endif
 
-  return 0;
+  return err;
 }

--- a/src/genmap-comm.c
+++ b/src/genmap-comm.c
@@ -89,7 +89,7 @@ int GenmapBcast(GenmapComm c, void *in, GenmapInt count, GenmapDataType type) {
   return MPI_Bcast(in, count, type, 0, c->gsc.c);
 }
 
-void GenmapSplitComm(genmap_handle h, GenmapComm *c, int bin) {
+void GenmapCommSplit(genmap_handle h, GenmapComm *c, int bin) {
   comm_ext local;
   int id = GenmapCommRank(*c);
   MPI_Comm_split((*c)->gsc.c, bin, id, &local);
@@ -116,4 +116,15 @@ int GenmapCrystalTransfer(genmap_handle h, int field) {
 int GenmapCrystalFinalize(genmap_handle h) {
   crystal_free(&(h->cr));
   return 0;
+}
+
+void comm_split(struct comm *old, int bin, int key, struct comm *new) {
+#ifdef MPI
+  MPI_Comm new_comm;
+  MPI_Comm_split(old->c, bin, key, &new_comm);
+  comm_init(new, new_comm);
+  MPI_Comm_free(&new_comm);
+#else
+  comm_init(new, 1);
+#endif
 }

--- a/src/genmap-debug-error.c
+++ b/src/genmap-debug-error.c
@@ -34,3 +34,10 @@ double GenmapGetMaxRss() {
   return (double)(r_usage.ru_maxrss * 1024L);
 #endif
 }
+
+void genmap_exit_error(genmap_handle h) {
+  GenmapComm c = GenmapGetGlobalComm(h);
+  int rank = GenmapCommRank(c);
+
+  genmap_finalize(h);
+}

--- a/src/genmap-rsb.c
+++ b/src/genmap-rsb.c
@@ -82,7 +82,7 @@ void genmap_rsb(genmap_handle h,int verbose){
     if(lc->id<(np+1)/2)
       bin=0;
     // FIXME: Ugly
-    GenmapSplitComm(h,&local_c,bin);
+    GenmapCommSplit(h,&local_c,bin);
     GenmapSetLocalComm(h,local_c);
     lc=&local_c->gsc;
     GenmapScan(h,local_c);

--- a/src/genmap.h
+++ b/src/genmap.h
@@ -55,9 +55,13 @@ void GenmapSetNVertices(genmap_handle h, int nVertices);
 
 void GenmapScan(genmap_handle h, GenmapComm c);
 
+/* GenmapComm */
 int GenmapCreateComm(GenmapComm *c, comm_ext ce);
 int GenmapCommSize(GenmapComm c);
 int GenmapCommRank(GenmapComm c);
+void GenmapCommSplit(genmap_handle h, GenmapComm *c, int bin);
+void comm_split(struct comm *old, int bin, int key, struct comm *new_);
+int GenmapDestroyComm(GenmapComm c);
 
 int GenmapGop(GenmapComm c, void *v, GenmapInt size, GenmapDataType type,
               GenmapInt op);
@@ -65,14 +69,13 @@ int GenmapReduce(GenmapComm c, void *out, void *in, GenmapInt size,
                  GenmapDataType type, GenmapInt op);
 int GenmapBcast(GenmapComm c, void *in, GenmapInt count, GenmapDataType type);
 
-int GenmapDestroyComm(GenmapComm c);
-void GenmapSplitComm(genmap_handle h, GenmapComm *c, int bin);
+int GenmapRead(genmap_handle h, void *data);
+
 int GenmapCrystalInit(genmap_handle h, GenmapComm c);
 int GenmapCrystalTransfer(genmap_handle h, int field);
 int GenmapCrystalFinalize(genmap_handle h);
 
-int GenmapRead(genmap_handle h, void *data);
-
+/* Genamp Vector */
 int GenmapCreateVector(GenmapVector *x, GenmapInt size);
 int GenmapSetVector(GenmapVector x, GenmapScalar *array);
 int GenmapGetVector(GenmapVector x, GenmapScalar *array);

--- a/src/parCon.c
+++ b/src/parCon.c
@@ -106,6 +106,10 @@ int parRSB_findConnectivity(long long *vertexid, double *coord, int nelt, int nd
   comm_allreduce(&c, gs_int, gs_max, &err, 1, &buf);
   check_error(err);
 
+  err = elementCheck(mesh, &c);
+  comm_allreduce(&c, gs_int, gs_max, &err, 1, &buf);
+  check_error(err);
+
   err = matchPeriodicFaces(mesh, &c, &bfr);
   check_error(err);
 


### PR DESCRIPTION
Make segment discovery consistent between serial and parallel.

- [x] Test on pyramid case
- [x] Check `conj_ht` example
- [x] Test on meshes in NekExamples (turbPipe, turbPipePeriodic, solid, expansion, hemi, peris, tgv, turbChannel, e3q)
- [x] Test at large scale (E = 62K, 524K, 1M)