### PR TITLE
Fix MPI hangs due to a break statement

### DIFF
--- a/src/genmap-rsb.c
+++ b/src/genmap-rsb.c
@@ -13,10 +13,8 @@ static int check_convergence(struct comm *gc, int max_pass, int max_iter) {
   for (i = 0; i < max_levels; i++) {
     sint converged = 1;
     int val = (int)metric_get_value(i, NFIEDLER);
-    if (val >= max_pass * max_iter) {
+    if (val >= max_pass * max_iter)
       converged = 0;
-      break;
-    }
 
     sint ibfr;
     comm_allreduce(gc, gs_int, gs_min, &converged, 1, &ibfr);


### PR DESCRIPTION
This fixes the hang issue @aprilnovak is facing with 32 MPI ranks.
@aprilnovak: Can you double check if this fixes your issue?