### PR TITLE
Fixes in parCon and parRSB for large runs

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -12,13 +12,12 @@ int NEIGHBOR_MAP[GC_MAX_VERTICES][GC_MAX_NEIGHBORS] = {
 void debug_print(const struct comm *c, int verbose, const char *fmt, ...) {
   comm_barrier(c);
   va_list vargs;
-  va_start(vargs, fmt);
   if (c->id == 0 && verbose > 0) {
+    va_start(vargs, fmt);
     vprintf(fmt, vargs);
+    va_end(vargs);
     fflush(stdout);
   }
-  fflush(stdout);
-  va_end(vargs);
 }
 
 double diff_sqr(double x, double y) { return (x - y) * (x - y); }

--- a/src/con.c
+++ b/src/con.c
@@ -9,7 +9,7 @@ int NEIGHBOR_MAP[GC_MAX_VERTICES][GC_MAX_NEIGHBORS] = {
     {1, 2, 4}, {0, 3, 5}, {0, 3, 6}, {1, 2, 7},
     {0, 5, 6}, {1, 4, 7}, {2, 4, 7}, {3, 5, 6}};
 
-void debug_print(struct comm *c, int verbose, const char *fmt, ...) {
+void debug_print(const struct comm *c, int verbose, const char *fmt, ...) {
   comm_barrier(c);
   va_list vargs;
   va_start(vargs, fmt);
@@ -17,6 +17,7 @@ void debug_print(struct comm *c, int verbose, const char *fmt, ...) {
     vprintf(fmt, vargs);
     fflush(stdout);
   }
+  fflush(stdout);
   va_end(vargs);
 }
 

--- a/src/parrsb-impl.h
+++ b/src/parrsb-impl.h
@@ -78,5 +78,5 @@ int log2ll(long long n);
 
 void parrsb_barrier(struct comm *c);
 
-void debug_print(struct comm *c, int verbose, const char *fmt, ...);
+void debug_print(const struct comm *c, int verbose, const char *fmt, ...);
 #endif

--- a/src/rsb-aux.c
+++ b/src/rsb-aux.c
@@ -355,9 +355,6 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
     // Sort by Fiedler vector
     debug_print(&lc, verbose, "\tSort ... %d\n", verbose);
     metric_tic(&lc, RSB_SORT);
-    // parallel_sort_2(struct rsb_element, elements, fiedler, gs_double,
-    // globalId,
-    //                 gs_long, 0, 1, &lc, bfr);
     parallel_sort(struct rsb_element, elements, fiedler, gs_double, 0, 1, &lc,
                   bfr);
     metric_toc(&lc, RSB_SORT);

--- a/src/rsb-aux.c
+++ b/src/rsb-aux.c
@@ -355,8 +355,11 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
     // Sort by Fiedler vector
     debug_print(&lc, verbose, "\tSort ... %d\n", verbose);
     metric_tic(&lc, RSB_SORT);
-    parallel_sort_2(struct rsb_element, elements, fiedler, gs_double, globalId,
-                    gs_long, 0, 1, &lc, bfr);
+    // parallel_sort_2(struct rsb_element, elements, fiedler, gs_double,
+    // globalId,
+    //                 gs_long, 0, 1, &lc, bfr);
+    parallel_sort(struct rsb_element, elements, fiedler, gs_double, 0, 1, &lc,
+                  bfr);
     metric_toc(&lc, RSB_SORT);
 
     // Attempt to repair if there are disconnected components

--- a/src/rsb-aux.c
+++ b/src/rsb-aux.c
@@ -309,8 +309,7 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
   }
 
   // Set verbosity.
-  // int verbose = options->verbose_level > 1;
-  int verbose = 2;
+  int verbose = options->verbose_level > 1;
 
   // Get number of partitions we are going to perform RSB on first level.
   sint np, nid;
@@ -377,9 +376,6 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
     get_part(&np, &nid, options->two_level, &lc, &nc);
     debug_print(&lc, verbose, "\tBisect ... %d\n", verbose);
     metric_push_level();
-
-    // Turning verbose off for subsequent levels.
-    verbose--;
   }
   comm_free(&lc);
 

--- a/src/rsb-aux.c
+++ b/src/rsb-aux.c
@@ -309,7 +309,8 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
   }
 
   // Set verbosity.
-  int verbose = options->verbose_level > 1;
+  // int verbose = options->verbose_level > 1;
+  int verbose = 2;
 
   // Get number of partitions we are going to perform RSB on first level.
   sint np, nid;
@@ -320,7 +321,7 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
   unsigned ndim = (nv == 8) ? 3 : 2;
   while (np > 1) {
     // Run the pre-partitioner.
-    debug_print(&lc, verbose, "\tPre-partitioner: ...\n");
+    debug_print(&lc, verbose, "\tPre-partitioner: ... %d\n", verbose);
     metric_tic(&lc, RSB_PRE);
     switch (options->rsb_pre) {
     case 0: // Sort by global id
@@ -339,7 +340,7 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
     metric_toc(&lc, RSB_PRE);
 
     // Find the Fiedler vector
-    debug_print(&lc, verbose, "\tFiedler ...\n");
+    debug_print(&lc, verbose, "\tFiedler ... %d\n", verbose);
     unsigned bin = (nid >= (np + 1) / 2);
     comm_split(&lc, bin, lc.id, &tc);
 
@@ -352,21 +353,21 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
     metric_toc(&lc, RSB_FIEDLER);
 
     // Sort by Fiedler vector
-    debug_print(&lc, verbose, "\tSort ...\n");
+    debug_print(&lc, verbose, "\tSort ... %d\n", verbose);
     metric_tic(&lc, RSB_SORT);
     parallel_sort_2(struct rsb_element, elements, fiedler, gs_double, globalId,
                     gs_long, 0, 1, &lc, bfr);
     metric_toc(&lc, RSB_SORT);
 
     // Attempt to repair if there are disconnected components
-    debug_print(&lc, verbose, "\tRepair ...\n");
+    debug_print(&lc, verbose, "\tRepair ... %d\n", verbose);
     metric_tic(&lc, RSB_REPAIR);
     if (options->repair)
       repair_partitions_v2(elements, nv, &tc, &lc, bin, options->rsb_pre, bfr);
     metric_toc(&lc, RSB_REPAIR);
 
     // Bisect and balance
-    debug_print(&lc, verbose, "\tBalance ...\n");
+    debug_print(&lc, verbose, "\tBalance ... %d\n", verbose);
     metric_tic(&lc, RSB_BALANCE);
     balance_partitions(elements, nv, &tc, &lc, bin, bfr);
     metric_toc(&lc, RSB_BALANCE);
@@ -374,11 +375,11 @@ int rsb(struct array *elements, int nv, int check, parrsb_options *options,
     // Split the communicator and recurse on the sub-problems.
     comm_free(&lc), comm_dup(&lc, &tc), comm_free(&tc);
     get_part(&np, &nid, options->two_level, &lc, &nc);
-    debug_print(&lc, verbose, "\tBisect ...\n");
+    debug_print(&lc, verbose, "\tBisect ... %d\n", verbose);
     metric_push_level();
 
     // Turning verbose off for subsequent levels.
-    verbose = 0;
+    verbose--;
   }
   comm_free(&lc);
 

--- a/src/rsb.c
+++ b/src/rsb.c
@@ -176,9 +176,10 @@ int parrsb_part_mesh(int *part, int *seq, long long *vtx, double *coord,
 
   update_options(&options);
 
-  debug_print(&c, options.verbose_level,
-              "Running parRSB ..., nv = %d, nelg = %lld\n", nv, nelg);
-  if (c.id == 0 && options.verbose_level > 0)
+  int verbose = options.verbose_level;
+  debug_print(&c, verbose, "Running parRSB ..., nv = %d, nelg = %lld\n", nv,
+              nelg);
+  if (c.id == 0 && verbose > 0)
     print_options(&options);
   fflush(stdout);
 
@@ -192,13 +193,13 @@ int parrsb_part_mesh(int *part, int *seq, long long *vtx, double *coord,
   buffer_init(&bfr, (nel + 1) * sizeof(struct rsb_element));
 
   // Load balance input data
-  debug_print(&c, options.verbose_level, "Load balance ...");
+  debug_print(&c, verbose, "Load balance: ...\n");
   struct array elist;
   size_t esize = load_balance(&elist, nel, nv, coord, vtx, &cr, &bfr);
-  debug_print(&c, options.verbose_level, " done.\n");
+  debug_print(&c, verbose, "Load balance: done.\n");
 
   // Run RSB now
-  debug_print(&c, options.verbose_level, "Running the partitioner ...");
+  debug_print(&c, verbose, "Running partitioner: ...\n");
   struct comm ca;
   comm_split(&c, elist.n > 0, c.id, &ca);
   metric_init();
@@ -225,14 +226,13 @@ int parrsb_part_mesh(int *part, int *seq, long long *vtx, double *coord,
     metric_rsb_print(&ca, options.profile_level);
   }
   metric_finalize(), comm_free(&ca);
-  debug_print(&c, options.verbose_level, " done.\n");
+  debug_print(&c, verbose, "Running partitioner: done.\n");
 
-  debug_print(&c, options.verbose_level, "Restore the original input ...");
+  debug_print(&c, verbose, "Restore original input: ...\n");
   restore_original(part, seq, &cr, &elist, esize, &bfr);
-  debug_print(&c, options.verbose_level, " done.\n");
+  debug_print(&c, verbose, "Restore original input: done.\n");
 
   // Report time and finish
-  parrsb_barrier(&c);
   debug_print(&c, 1, "par%s finished in %g seconds.\n",
               ALGO[options.partitioner], comm_time() - t);
 

--- a/src/sort-bin.c
+++ b/src/sort-bin.c
@@ -1,0 +1,91 @@
+#include "sort-impl.h"
+
+static uint *set_proc_from_val(struct sort *s, uint field,
+                               const struct comm *c) {
+  struct array *a = s->a;
+  gs_dom t = s->t[field];
+  uint offset = s->offset[field];
+
+  uint size = a->n;
+  uint *proc = tcalloc(uint, size + 1);
+
+  double extrema[2];
+  get_extrema((void *)extrema, s, field, c);
+  double range = extrema[1] - extrema[0];
+
+  if (size == 0)
+    return 0;
+
+  sint np = c->np;
+  uint id = 0;
+  uint index = 0;
+  do {
+    double end = extrema[0] + (range / np) * (id + 1);
+    while (index < size) {
+      double val = get_scalar(a, index, offset, s->unit_size, t);
+      if (val <= end)
+        proc[index] = id, index++;
+      else
+        break;
+    }
+    id++;
+  } while (id < np && index < size);
+  for (; index < size; index++)
+    proc[index] = np - 1;
+  return 0;
+}
+
+void parallel_bin_sort(struct sort *s, const struct comm *c) {
+  // Locally sort the array first.
+  sort_local(s);
+
+  // Set destination bin based on the field value.
+  uint *proc = set_proc_from_val(s, 0, c);
+
+  // Calculate the global array size. If it is zero, nothing to do, just return.
+  struct array *arr = s->a;
+  slong ng = arr->n, wrk[2];
+  comm_allreduce(c, gs_long, gs_add, &ng, 1, wrk);
+  if (ng == 0)
+    return;
+
+  // Initialize the crystal router.
+  struct crystal cr;
+  crystal_init(&cr, c);
+
+  // Transfer the array elements to destination processor. To avoid message
+  // sizes larger than INT_MAX, we calculate total message size and then figure
+  // out how many transfers we need. Then we transfer array using that many
+  // transfers.
+  size_t usize = s->unit_size;
+  uint nt = 2 * ((ng * usize + INT_MAX - 1) / INT_MAX);
+  uint tsize = (arr->n + nt - 1) / nt;
+
+  struct array brr, crr;
+  array_init_(&brr, tsize + 1, usize, __FILE__, __LINE__);
+  array_init_(&crr, arr->n + 1, usize, __FILE__, __LINE__);
+
+  char *pe = (char *)arr->ptr;
+  uint off = 0;
+  for (unsigned i = 0; i < nt; i++) {
+    // Copy from arr to brr.
+    brr.n = 0;
+    uint off1 = off + tsize;
+    for (uint j = off; j < arr->n && j < off1; j++)
+      array_cat_(usize, &brr, &pe[j * usize], 1, __FILE__, __LINE__);
+    sarray_transfer_ext_(&brr, usize, &proc[off], sizeof(uint), &cr);
+    array_cat_(usize, &crr, brr.ptr, brr.n, __FILE__, __LINE__);
+    off = (off1 < arr->n ? off1 : arr->n);
+  }
+  array_free(&brr), free(proc);
+
+  arr->n = 0;
+  array_cat_(usize, arr, crr.ptr, crr.n, __FILE__, __LINE__);
+  array_free(&crr);
+
+  crystal_free(&cr);
+
+  // Locally sort again to make sure that we have both globally and locally
+  // sorted array.
+  sort_local(s);
+}

--- a/src/sort-bin.c
+++ b/src/sort-bin.c
@@ -7,7 +7,7 @@ static uint *set_proc_from_val(struct sort *s, uint field,
   uint offset = s->offset[field];
 
   uint size = a->n;
-  uint *proc = tcalloc(uint, size + 1);
+  uint *proc = tcalloc(uint, size);
 
   double extrema[2];
   get_extrema((void *)extrema, s, field, c);

--- a/src/sort-bin.c
+++ b/src/sort-bin.c
@@ -32,7 +32,7 @@ static uint *set_proc_from_val(struct sort *s, uint field,
   } while (id < np && index < size);
   for (; index < size; index++)
     proc[index] = np - 1;
-  return 0;
+  return proc;
 }
 
 void parallel_bin_sort(struct sort *s, const struct comm *c) {
@@ -42,48 +42,9 @@ void parallel_bin_sort(struct sort *s, const struct comm *c) {
   // Set destination bin based on the field value.
   uint *proc = set_proc_from_val(s, 0, c);
 
-  // Calculate the global array size. If it is zero, nothing to do, just return.
-  struct array *arr = s->a;
-  slong ng = arr->n, wrk[2];
-  comm_allreduce(c, gs_long, gs_add, &ng, 1, wrk);
-  if (ng == 0)
-    return;
-
-  // Initialize the crystal router.
-  struct crystal cr;
-  crystal_init(&cr, c);
-
-  // Transfer the array elements to destination processor. To avoid message
-  // sizes larger than INT_MAX, we calculate total message size and then figure
-  // out how many transfers we need. Then we transfer array using that many
-  // transfers.
-  size_t usize = s->unit_size;
-  uint nt = 2 * ((ng * usize + INT_MAX - 1) / INT_MAX);
-  uint tsize = (arr->n + nt - 1) / nt;
-
-  struct array brr, crr;
-  array_init_(&brr, tsize + 1, usize, __FILE__, __LINE__);
-  array_init_(&crr, arr->n + 1, usize, __FILE__, __LINE__);
-
-  char *pe = (char *)arr->ptr;
-  uint off = 0;
-  for (unsigned i = 0; i < nt; i++) {
-    // Copy from arr to brr.
-    brr.n = 0;
-    uint off1 = off + tsize;
-    for (uint j = off; j < arr->n && j < off1; j++)
-      array_cat_(usize, &brr, &pe[j * usize], 1, __FILE__, __LINE__);
-    sarray_transfer_ext_(&brr, usize, &proc[off], sizeof(uint), &cr);
-    array_cat_(usize, &crr, brr.ptr, brr.n, __FILE__, __LINE__);
-    off = (off1 < arr->n ? off1 : arr->n);
-  }
-  array_free(&brr), free(proc);
-
-  arr->n = 0;
-  array_cat_(usize, arr, crr.ptr, crr.n, __FILE__, __LINE__);
-  array_free(&crr);
-
-  crystal_free(&cr);
+  // Transfer the array in chunks.
+  sarray_transfer_chunk(s->a, s->unit_size, proc, c);
+  free(proc);
 
   // Locally sort again to make sure that we have both globally and locally
   // sorted array.

--- a/src/sort-hypercube.c
+++ b/src/sort-hypercube.c
@@ -1,0 +1,155 @@
+#include "sort-impl.h"
+#include <math.h>
+
+static int init_probes(struct hypercube *data, struct comm *c) {
+  struct sort *input = data->data;
+
+  // Allocate space for probes and counts
+  int nprobes = data->nprobes = 3;
+  if (!data->probes)
+    data->probes = tcalloc(double, nprobes);
+  if (!data->probe_cnt)
+    data->probe_cnt = tcalloc(ulong, nprobes);
+
+  double extrema[2];
+  get_extrema((void *)extrema, data->data, 0, c);
+  double range = extrema[1] - extrema[0];
+  double delta = range / (nprobes - 1);
+
+  data->probes[0] = extrema[0];
+  data->probes[1] = extrema[0] + delta;
+  data->probes[2] = extrema[1];
+
+  return 0;
+}
+
+static int update_probe_counts(struct hypercube *data, struct comm *c) {
+  struct sort *input = data->data;
+  uint offset = input->offset[0];
+  gs_dom t = input->t[0];
+
+  uint nprobes = data->nprobes;
+  uint i;
+  for (i = 0; i < nprobes; i++)
+    data->probe_cnt[i] = 0;
+
+  struct array *a = input->a;
+  uint e;
+  for (e = 0; e < a->n; e++) {
+    double val_e = get_scalar(a, e, offset, input->unit_size, t);
+    for (i = 0; i < nprobes; i++)
+      if (val_e < data->probes[i])
+        data->probe_cnt[i]++;
+  }
+
+  slong buf[6];
+  comm_allreduce(c, gs_long, gs_add, data->probe_cnt, nprobes, buf);
+
+  return 0;
+}
+
+static int update_probes(slong nelem, double *probes, ulong *probe_cnt,
+                         uint threshold) {
+  slong expected = nelem / 2;
+  if (llabs(expected - (slong)probe_cnt[1]) < threshold)
+    return 0;
+
+  if (probe_cnt[1] < expected)
+    probes[0] = probes[1];
+  else
+    probes[2] = probes[1];
+
+  probes[1] = probes[0] + (probes[2] - probes[0]) / 2.0;
+
+  return 0;
+}
+
+static int transfer_elem(struct hypercube *data, struct comm *c) {
+  struct sort *input = data->data;
+  uint usize = input->unit_size, offset = input->offset[0];
+  gs_dom t = input->t[0];
+  struct array *a = input->a;
+
+  uint size = a->n, lown = 0, uppern = 0;
+  for (uint e = 0; e < size; e++) {
+    double val = get_scalar(a, e, offset, usize, t);
+    if (val < data->probes[1])
+      lown++;
+    else
+      uppern++;
+  }
+
+  slong out[2][2], in[2] = {lown, uppern}, buf[2][2];
+  comm_scan(out, c, gs_long, gs_add, in, 2, buf);
+  slong lstart = out[0][0], ustart = out[0][1];
+  slong lelem = out[1][0], uelem = out[1][1];
+
+  uint np = c->np, lnp = np / 2;
+  uint *proc = tcalloc(uint, size);
+  set_proc_from_idx(proc, lnp, lstart, lown, lelem);
+  set_proc_from_idx(proc + lown, np - lnp, ustart, uppern, uelem);
+
+  for (uint e = lown; e < size; e++)
+    proc[e] += lnp;
+
+  struct crystal cr;
+  crystal_init(&cr, c);
+  sarray_transfer_ext_(a, usize, proc, sizeof(uint), &cr);
+  crystal_free(&cr);
+
+  free(proc);
+
+  return 0;
+}
+
+void parallel_hypercube_sort(struct hypercube *data, struct comm *c) {
+  struct sort *input = data->data;
+  struct array *a = input->a;
+  gs_dom t = input->t[0];
+  uint offset = input->offset[0];
+
+  sint size = c->np, rank = c->id;
+
+  slong out[2][1], buf[2][1], in = a->n;
+  comm_scan(out, c, gs_long, gs_add, &in, 1, buf);
+  slong start = out[0][0];
+  slong nelem = out[1][0];
+
+  uint threshold = nelem / (10 * size);
+  if (threshold < 2)
+    threshold = 2;
+
+  sort_local(data->data);
+
+  if (size == 1)
+    return;
+
+  init_probes(data, c);
+  update_probe_counts(data, c);
+
+  int max_iter = log2((data->probes[2] - data->probes[0]) / 1e-12);
+  int iter = 0;
+  while (llabs(nelem / 2 - (slong)data->probe_cnt[1]) > threshold &&
+         iter++ < max_iter) {
+    update_probes(nelem, data->probes, data->probe_cnt, threshold);
+    update_probe_counts(data, c);
+  }
+
+  transfer_elem(data, c);
+
+  // split the communicator
+  struct comm nc;
+  sint lower = (rank < size / 2) ? 1 : 0;
+#if defined(MPI)
+  MPI_Comm nc_;
+  MPI_Comm_split(c->c, lower, rank, &nc_);
+  comm_init(&nc, nc_);
+  MPI_Comm_free(&nc_);
+#else
+  comm_init(&nc, 1);
+#endif
+
+  // TODO: Keep load balancing after each split
+  parallel_hypercube_sort(data, &nc);
+  comm_free(&nc);
+}

--- a/src/sort-hypercube.c
+++ b/src/sort-hypercube.c
@@ -85,7 +85,7 @@ static int transfer_elem(struct hypercube *data, struct comm *c) {
   slong lelem = out[1][0], uelem = out[1][1];
 
   uint np = c->np, lnp = np / 2;
-  uint *proc = tcalloc(uint, size);
+  uint *proc = tcalloc(uint, size + 1);
   set_proc_from_idx(proc, lnp, lstart, lown, lelem);
   set_proc_from_idx(proc + lown, np - lnp, ustart, uppern, uelem);
 

--- a/src/sort-impl.h
+++ b/src/sort-impl.h
@@ -23,7 +23,7 @@ struct hypercube {
   double *probes;
   ulong *probe_cnt;
 };
-void parallel_hypercube_sort(struct hypercube *data, struct comm *c);
+void parallel_hypercube_sort(struct hypercube *data, const struct comm *c);
 
 void parallel_bin_sort(struct sort *s, const struct comm *c);
 

--- a/src/sort-impl.h
+++ b/src/sort-impl.h
@@ -5,11 +5,17 @@
 
 double get_scalar(struct array *a, uint i, uint offset, uint usize,
                   gs_dom type);
+
 void get_extrema(void *extrema_, struct sort *data, uint field,
                  const struct comm *c);
+
 void set_proc_from_idx(uint *proc, uint size, sint np, slong start,
                        slong nelem);
+
 void sort_local(struct sort *s);
+
+void sarray_transfer_chunk(struct array *arr, const size_t usize,
+                           const uint *proc, const struct comm *c);
 
 struct hypercube {
   struct sort *data;

--- a/src/sort-impl.h
+++ b/src/sort-impl.h
@@ -1,0 +1,24 @@
+#ifndef _PARRSB_SORT_IMPL_H_
+#define _PARRSB_SORT_IMPL_H_
+
+#include "sort.h"
+
+double get_scalar(struct array *a, uint i, uint offset, uint usize,
+                  gs_dom type);
+void get_extrema(void *extrema_, struct sort *data, uint field,
+                 const struct comm *c);
+void set_proc_from_idx(uint *proc, uint size, sint np, slong start,
+                       slong nelem);
+void sort_local(struct sort *s);
+
+struct hypercube {
+  struct sort *data;
+  int nprobes;
+  double *probes;
+  ulong *probe_cnt;
+};
+void parallel_hypercube_sort(struct hypercube *data, struct comm *c);
+
+void parallel_bin_sort(struct sort *s, const struct comm *c);
+
+#endif // _PARRSB_SORT_IMPL_H_

--- a/src/sort.c
+++ b/src/sort.c
@@ -96,7 +96,7 @@ static int set_bin(uint **proc_, struct sort *s, uint field,
     while (index < size) {
       double val = get_scalar(a, index, offset, s->unit_size, t);
       if (val <= end)
-        proc[index++] = id;
+        proc[index] = id, index++;
       else
         break;
     }
@@ -351,12 +351,10 @@ int parallel_sort_private(struct sort *data, const struct comm *c) {
   comm_dup(&dup, c);
 
   int balance = data->balance, algo = data->algo;
-
   struct array *a = data->a;
   size_t usize = data->unit_size;
 
   struct hypercube hdata;
-
   switch (algo) {
   case 0:
     parallel_bin_sort(data, c);
@@ -380,7 +378,6 @@ int parallel_sort_private(struct sort *data, const struct comm *c) {
     crystal_free(&cr);
     sort_local(data);
   }
-
   comm_free(&dup);
 
   return 0;

--- a/src/sort.c
+++ b/src/sort.c
@@ -133,7 +133,9 @@ void sarray_transfer_chunk(struct array *arr, const size_t usize,
   // sizes larger than INT_MAX, we calculate total message size and then figure
   // out how many transfers we need. Then we transfer array using that many
   // transfers.
-  uint nt = 2 * ((ng * usize + INT_MAX - 1) / INT_MAX);
+  slong msg_size = INT_MAX;
+  msg_size *= 2;
+  uint nt = (ng * usize + msg_size - 1) / msg_size;
   uint tsize = (arr->n + nt - 1) / nt;
 
   struct array brr, crr;

--- a/src/sort.h
+++ b/src/sort.h
@@ -16,10 +16,8 @@ struct sort {
   buffer *buf;
 };
 
-int sort_local(struct sort *s);
-int parallel_sort_private(struct sort *s, const struct comm *c);
+void parallel_sort_private(struct sort *s, const struct comm *c);
 
-// Uniform parallel sort
 #define parallel_sort(T, A, field, type, method, loadbalance, c, bufp)         \
   do {                                                                         \
     struct sort sd;                                                            \


### PR DESCRIPTION
In parCon, a certain `gs()` call ended up doing a reduction with `gs_pairwise` which is not scalable.
For very large elements, MPI message sizes in parRSB exceeded `INT_MAX`. It was fixed by sending
such messages by chunks. Also, this PR includes a refactor of the parallel sort files.

- [x] Test on the failing Kershaw mesh.
- [x] Test on a few other large meshes at scale.
- [x] Run the regression tests on Frontier.